### PR TITLE
Exactly match tenant Id

### DIFF
--- a/.circleci/duplo_utils.sh
+++ b/.circleci/duplo_utils.sh
@@ -145,7 +145,7 @@ get_tenant_id(){
    local tenant="${1:-}"
    [ $# -eq 0 ] || shift
    [ -z "${tenant:-}" ] && die "Internal error: no tenant id is provided"
-   duplo_api "adminproxy/GetTenantNames" | jq -c ".[] | select( .AccountName | contains(\"${tenant}\"))" | jq -r '.TenantId'
+   duplo_api "adminproxy/GetTenantNames" | jq -c ".[] | select( .AccountName == \"${tenant}\" )" | jq -r '.TenantId'
 }
 
 install_dependencies(){


### PR DESCRIPTION
## Overview

Match tenant name exactly to avoid returning multiple values.

Coverforce had reported the issue when their CI stopped working after they added a new Tenant which matched a prefix with another tenant, so the contains() method returned both tenant and that caused failures downstream.